### PR TITLE
Fix repository tests for H2

### DIFF
--- a/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/MvcAdminApplicationTests.java
+++ b/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/MvcAdminApplicationTests.java
@@ -6,7 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb",
         "spring.datasource.driver-class-name=org.h2.Driver",
-        "spring.jpa.hibernate.ddl-auto=create-drop"
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
 })
 class MvcAdminApplicationTests {
 

--- a/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/repository/CorregoRepositoryTest.java
+++ b/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/repository/CorregoRepositoryTest.java
@@ -9,7 +9,10 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@DataJpaTest
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect"
+})
 class CorregoRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## Summary
- set the H2 dialect when running tests
- ensure schema is generated for repository tests

## Testing
- `mvn test` *(fails: Non-resolvable parent POM due to network issue)*

------
https://chatgpt.com/codex/tasks/task_e_68436197a5e8832bb44bf34f5c7e9944