### PR TITLE
Add manual reading creation

### DIFF
--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/controller/LeituraSensorController.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/controller/LeituraSensorController.java
@@ -1,12 +1,16 @@
 package com.alerta_sp.mvc_admin.controller;
 
 import com.alerta_sp.mvc_admin.dto.CorregoView;
+import com.alerta_sp.mvc_admin.dto.LeituraFormDTO;
+import com.alerta_sp.mvc_admin.dto.SensorView;
 import com.alerta_sp.mvc_admin.service.CorregoService;
 import com.alerta_sp.mvc_admin.service.LeituraSensorService;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -38,6 +42,20 @@ public class LeituraSensorController {
         List<CorregoView> listaCorregos = corregoService.listarTodos();
         model.addAttribute("corregos", listaCorregos);
         return "gestao_leitura_sensores";
+    }
+
+    @GetMapping("/leitura/novo")
+    public String novaLeituraForm(Model model) {
+        List<SensorView> sensores = leituraSensorService.listarSensoresDisponiveis();
+        model.addAttribute("leitura", new LeituraFormDTO());
+        model.addAttribute("sensores", sensores);
+        return "formulario_leitura";
+    }
+
+    @PostMapping("/leitura")
+    public String salvarNovaLeitura(@ModelAttribute("leitura") LeituraFormDTO leitura) {
+        leituraSensorService.salvar(leitura);
+        return "redirect:/admin/dashboard";
     }
 
     /**

--- a/mvc-admin/src/main/resources/messages_en.properties
+++ b/mvc-admin/src/main/resources/messages_en.properties
@@ -89,6 +89,12 @@ leituras.inicio=In�cio
 leituras.fim=Fim
 leituras.filtrar=Filtrar
 leituras.voltar=Voltar
+leituras.novo=Add New Reading
+leituras.novoTitulo=New Reading
+leituras.sensor=Sensor
+leituras.nivel=Level
+leituras.salvar=Save
+leituras.cancelar=Cancel
 
 #Alertas
 alertas.titulo=Issued Alerts

--- a/mvc-admin/src/main/resources/messages_es.properties
+++ b/mvc-admin/src/main/resources/messages_es.properties
@@ -86,6 +86,12 @@ leituras.inicio=Inicio
 leituras.fim=Fin
 leituras.filtrar=Filtrar
 leituras.voltar=Volver
+leituras.novo=Registrar Nueva Lectura
+leituras.novoTitulo=Nueva Lectura
+leituras.sensor=Sensor
+leituras.nivel=Nivel
+leituras.salvar=Guardar
+leituras.cancelar=Cancelar
 
 # Alertas
 alertas.titulo=Alertas Emitidos

--- a/mvc-admin/src/main/resources/messages_pt_BR.properties
+++ b/mvc-admin/src/main/resources/messages_pt_BR.properties
@@ -88,6 +88,12 @@ leituras.inicio=Início
 leituras.fim=Fim
 leituras.filtrar=Filtrar
 leituras.voltar=Voltar
+leituras.novo=Cadastrar Nova Leitura
+leituras.novoTitulo=Nova Leitura
+leituras.sensor=Sensor
+leituras.nivel=Nível
+leituras.salvar=Salvar
+leituras.cancelar=Cancelar
 
 # Alertas
 alertas.titulo=Alertas Emitidos

--- a/mvc-admin/src/main/resources/templates/formulario_leitura.html
+++ b/mvc-admin/src/main/resources/templates/formulario_leitura.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title th:text="#{leituras.novoTitulo}">Nova Leitura</title>
+    <style>
+        body { margin: 0; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; background-color: #f5f7fa; color: #333; }
+        header { background-color: #1e3c72; color: white; padding: 1rem 2rem; display: flex; justify-content: space-between; align-items: center; }
+        .language-bar a { color: #fff; margin: 0 0.5rem; text-decoration: none; }
+        .container { max-width: 600px; margin: 2rem auto; background: white; padding: 2rem; border-radius: 10px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        label { display: block; margin: 0.5rem 0 0.2rem; font-weight: bold; }
+        input, select { width: 100%; padding: 0.6rem; border: 1px solid #ccc; border-radius: 5px; margin-bottom: 1rem; }
+        .btn-container { display: flex; justify-content: space-between; gap: 1rem; }
+        .btn { padding: 0.8rem; border: none; border-radius: 5px; font-size: 1rem; cursor: pointer; color: white; text-decoration: none; width: 100%; }
+        .btn-salvar { background-color: #28a745; }
+        .btn-cancelar { background-color: #6c757d; }
+    </style>
+</head>
+<body>
+<header>
+    <h1 th:text="#{leituras.novoTitulo}">Nova Leitura</h1>
+    <div class="language-bar">
+        🌐 <a th:href="@{'?lang=pt_BR'}">Português</a> |
+        <a th:href="@{'?lang=en'}">English</a> |
+        <a th:href="@{'?lang=es'}">Español</a>
+    </div>
+</header>
+
+<div class="container">
+    <form th:action="@{/admin/leitura}" th:object="${leitura}" method="post">
+        <label for="idSensor" th:text="#{leituras.sensor}">Sensor</label>
+        <select id="idSensor" th:field="*{idSensor}" required>
+            <option value="" disabled selected>Selecione</option>
+            <option th:each="s : ${sensores}" th:value="${s.id}" th:text="${s.codigo}"></option>
+        </select>
+
+        <label for="nivel" th:text="#{leituras.nivel}">Nível</label>
+        <input type="number" step="0.01" id="nivel" th:field="*{nivel}" required>
+
+        <div class="btn-container">
+            <button type="submit" class="btn btn-salvar" th:text="#{leituras.salvar}">Salvar</button>
+            <a th:href="@{/admin/dashboard}" class="btn btn-cancelar" th:text="#{leituras.cancelar}">Cancelar</a>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/mvc-admin/src/main/resources/templates/gestao_leitura_sensores.html
+++ b/mvc-admin/src/main/resources/templates/gestao_leitura_sensores.html
@@ -69,6 +69,18 @@
             margin-top: 2rem;
         }
 
+        .btn-novo {
+            background-color: #28a745;
+            color: white;
+            padding: 0.6rem 1.2rem;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            text-decoration: none;
+            display: inline-block;
+            margin-bottom: 1rem;
+        }
+
         .btn-voltar {
             background-color: #6c757d;
             color: white;
@@ -118,6 +130,8 @@
     </form>
 
     <canvas id="graficoLeituras" height="100"></canvas>
+
+    <a th:href="@{/admin/leitura/novo}" class="btn-novo" th:text="#{leituras.novo}">Nova Leitura</a>
 
     <a th:href="@{/admin/dashboard}" class="btn-voltar" th:text="#{leituras.voltar}">Voltar</a>
 </div>

--- a/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/service/impl/LeituraSensorServiceImplTest.java
+++ b/mvc-admin/src/test/java/com/alerta_sp/mvc_admin/service/impl/LeituraSensorServiceImplTest.java
@@ -1,0 +1,64 @@
+package com.alerta_sp.mvc_admin.service.impl;
+
+import com.alerta_sp.mvc_admin.dto.LeituraFormDTO;
+import com.alerta_sp.mvc_admin.dto.LeituraView;
+import com.alerta_sp.mvc_admin.model.LeituraSensor;
+import com.alerta_sp.mvc_admin.model.Sensor;
+import com.alerta_sp.mvc_admin.repository.LeituraSensorRepository;
+import com.alerta_sp.mvc_admin.repository.SensorRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LeituraSensorServiceImplTest {
+
+    @Mock
+    private LeituraSensorRepository leituraRepo;
+    @Mock
+    private SensorRepository sensorRepo;
+
+    @InjectMocks
+    private LeituraSensorServiceImpl service;
+
+    @Test
+    void salvarDeveLancarExcecaoQuandoSensorNaoExiste() {
+        LeituraFormDTO dto = new LeituraFormDTO();
+        dto.setIdSensor(1L);
+        dto.setNivel(1.2);
+
+        when(sensorRepo.findById(1L)).thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class, () -> service.salvar(dto));
+    }
+
+    @Test
+    void salvarDevePersistirQuandoDadosValidos() {
+        LeituraFormDTO dto = new LeituraFormDTO();
+        dto.setIdSensor(1L);
+        dto.setNivel(2.5);
+
+        Sensor sensor = new Sensor();
+        ReflectionTestUtils.setField(sensor, "id", 1L);
+        when(sensorRepo.findById(1L)).thenReturn(Optional.of(sensor));
+
+        LeituraSensor salvo = new LeituraSensor();
+        ReflectionTestUtils.setField(salvo, "id", 10L);
+        salvo.setSensor(sensor);
+        salvo.setNivel(2.5);
+        when(leituraRepo.save(any(LeituraSensor.class))).thenReturn(salvo);
+
+        LeituraView view = service.salvar(dto);
+        assertEquals(10L, view.id());
+        assertEquals(2.5, view.nivel());
+    }
+}


### PR DESCRIPTION
## Summary
- create HTML form for manual sensor readings
- internationalize new reading fields
- add controller endpoints for manual reading simulation
- provide unit tests for LeituraSensorService
- add button on readings management page to open the manual reading form

## Testing
- `./mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684553bb0ea0832bb290e704c5e44491