### PR TITLE
Enable dynamic chart data loading

### DIFF
--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/controller/LeituraSensorController.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/controller/LeituraSensorController.java
@@ -3,6 +3,7 @@ package com.alerta_sp.mvc_admin.controller;
 import com.alerta_sp.mvc_admin.dto.CorregoView;
 import com.alerta_sp.mvc_admin.dto.LeituraFormDTO;
 import com.alerta_sp.mvc_admin.dto.SensorView;
+import com.alerta_sp.mvc_admin.dto.LeituraDTO;
 import com.alerta_sp.mvc_admin.service.CorregoService;
 import com.alerta_sp.mvc_admin.service.LeituraSensorService;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -79,6 +81,12 @@ public class LeituraSensorController {
         model.addAttribute("corregos", listaCorregos);
 
         return "gestao_leitura_sensores";
+    }
+
+    // Endpoint REST para fornecer as leituras ao gráfico via fetch()
+    @GetMapping("/leituras/dados")
+    public @ResponseBody List<LeituraDTO> obterLeituras(@RequestParam("idCorrego") Long idCorrego) {
+        return leituraSensorService.buscarUltimasLeituras(idCorrego);
     }
 
 }

--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/dto/LeituraDTO.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/dto/LeituraDTO.java
@@ -1,0 +1,13 @@
+package com.alerta_sp.mvc_admin.dto;
+
+import com.alerta_sp.mvc_admin.model.LeituraSensor;
+
+import java.time.format.DateTimeFormatter;
+
+public record LeituraDTO(String dataHora, Double nivel) {
+    public static LeituraDTO fromEntity(LeituraSensor leitura) {
+        String formatada = leitura.getDataHora()
+                .format(DateTimeFormatter.ofPattern("HH:mm"));
+        return new LeituraDTO(formatada, leitura.getNivel());
+    }
+}

--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/repository/LeituraSensorRepository.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/repository/LeituraSensorRepository.java
@@ -4,8 +4,12 @@ import com.alerta_sp.mvc_admin.model.LeituraSensor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface LeituraSensorRepository extends JpaRepository<LeituraSensor, Long> {
 
     Optional<LeituraSensor> findTopBySensor_Corrego_IdOrderByDataHoraDesc(Long corregoId);
+
+    // Retorna as 24 leituras mais recentes de um determinado córrego
+    List<LeituraSensor> findTop24BySensor_Corrego_IdOrderByDataHoraDesc(Long corregoId);
 }

--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/service/LeituraSensorService.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/service/LeituraSensorService.java
@@ -2,6 +2,7 @@ package com.alerta_sp.mvc_admin.service;
 
 import com.alerta_sp.mvc_admin.dto.LeituraFormDTO;
 import com.alerta_sp.mvc_admin.dto.LeituraView;
+import com.alerta_sp.mvc_admin.dto.LeituraDTO;
 import com.alerta_sp.mvc_admin.dto.SensorView;  // vamos reutilizar SensorView para dropdown
 import java.util.List;
 import java.util.Optional;
@@ -13,5 +14,7 @@ public interface LeituraSensorService {
     Optional<LeituraView> buscarPorId(Long id);
     void deletarPorId(Long id);
     List<SensorView> listarSensoresDisponiveis();
+
+    List<LeituraDTO> buscarUltimasLeituras(Long idCorrego);
 
 }

--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/service/impl/LeituraSensorServiceImpl.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/service/impl/LeituraSensorServiceImpl.java
@@ -3,6 +3,7 @@ package com.alerta_sp.mvc_admin.service.impl;
 import com.alerta_sp.mvc_admin.dto.LeituraFormDTO;
 import com.alerta_sp.mvc_admin.dto.LeituraView;
 import com.alerta_sp.mvc_admin.dto.SensorView;
+import com.alerta_sp.mvc_admin.dto.LeituraDTO;
 import com.alerta_sp.mvc_admin.model.LeituraSensor;
 import com.alerta_sp.mvc_admin.model.Sensor;
 import com.alerta_sp.mvc_admin.repository.LeituraSensorRepository;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 
 @Service
 @Transactional
@@ -62,6 +65,19 @@ public class LeituraSensorServiceImpl implements LeituraSensorService {
     public List<SensorView> listarSensoresDisponiveis() {
         return sensorRepository.findAll().stream()
                 .map(SensorView::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<LeituraDTO> buscarUltimasLeituras(Long idCorrego) {
+        return leituraSensorRepository
+                .findTop24BySensor_Corrego_IdOrderByDataHoraDesc(idCorrego)
+                .stream()
+                .sorted(Comparator.comparing(LeituraSensor::getDataHora))
+                .map(l -> new LeituraDTO(
+                        l.getDataHora().format(DateTimeFormatter.ofPattern("HH:mm")),
+                        l.getNivel()
+                ))
                 .collect(Collectors.toList());
     }
 }

--- a/mvc-admin/src/main/resources/templates/dashboard.html
+++ b/mvc-admin/src/main/resources/templates/dashboard.html
@@ -196,7 +196,7 @@
       </tr>
       </thead>
       <tbody>
-      <tr th:each="corrego : ${corregos}">
+      <tr th:each="corrego : ${corregos}" th:data-id="${corrego.id}">
         <td th:text="${corrego.nome}">Córrego A</td>
         <td th:text="${#numbers.formatDecimal(corrego.nivelAtual, 1, 'COMMA', 1, 'POINT')} + ' m'">1.2 m</td>
         <td>
@@ -235,28 +235,50 @@
 
 <script>
   const ctx = document.getElementById('nivelChart');
-  const nivelChart = new Chart(ctx, {
-    type: 'line',
-    data: {
-      labels: ['00h', '04h', '08h', '12h', '16h', '20h'],
-      datasets: [{
-        label: 'Nível do Córrego A (m)',
-        data: [1.1, 1.3, 1.5, 1.7, 1.8, 2.1],
-        borderColor: 'rgba(30, 60, 114, 1)',
-        backgroundColor: 'rgba(30, 60, 114, 0.1)',
-        fill: true,
-        tension: 0.4
-      }]
-    },
-    options: {
-      responsive: true,
-      scales: {
-        y: {
-          beginAtZero: true
+  let nivelChart;
+
+  function carregarGrafico(idCorrego) {
+    fetch(`/admin/leituras/dados?idCorrego=${idCorrego}`)
+      .then(r => r.json())
+      .then(dados => {
+        const labels = dados.map(d => d.dataHora);
+        const valores = dados.map(d => d.nivel);
+
+        if (nivelChart) {
+          nivelChart.data.labels = labels;
+          nivelChart.data.datasets[0].data = valores;
+          nivelChart.update();
+        } else {
+          nivelChart = new Chart(ctx, {
+            type: 'line',
+            data: {
+              labels: labels,
+              datasets: [{
+                label: 'Nível do Córrego (m)',
+                data: valores,
+                borderColor: 'rgba(30, 60, 114, 1)',
+                backgroundColor: 'rgba(30, 60, 114, 0.1)',
+                fill: true,
+                tension: 0.4
+              }]
+            },
+            options: {
+              responsive: true,
+              scales: {
+                y: {
+                  beginAtZero: true
+                }
+              }
+            }
+          });
         }
-      }
-    }
-  });
+      });
+  }
+
+  const primeiro = document.querySelector('[data-id]');
+  if (primeiro) {
+    carregarGrafico(primeiro.dataset.id);
+  }
 
   function toggleMenu() {
     const menu = document.getElementById('menu');

--- a/mvc-admin/src/main/resources/templates/gestao_leitura_sensores.html
+++ b/mvc-admin/src/main/resources/templates/gestao_leitura_sensores.html
@@ -138,27 +138,50 @@
 
 <script>
     const ctx = document.getElementById('graficoLeituras');
-    const graficoLeituras = new Chart(ctx, {
-        type: 'line',
-        data: {
-            labels: ['01/05', '02/05', '03/05', '04/05'],
-            datasets: [{
-                label: 'Nível do Córrego (m)',
-                data: [1.2, 1.5, 1.8, 2.0],
-                borderColor: '#1e3c72',
-                backgroundColor: 'rgba(30, 60, 114, 0.1)',
-                fill: true,
-                tension: 0.4
-            }]
-        },
-        options: {
-            responsive: true,
-            scales: {
-                y: {
-                    beginAtZero: true
+    let graficoLeituras;
+
+    function carregarGrafico(idCorrego) {
+        fetch(`/admin/leituras/dados?idCorrego=${idCorrego}`)
+            .then(r => r.json())
+            .then(dados => {
+                const labels = dados.map(d => d.dataHora);
+                const valores = dados.map(d => d.nivel);
+
+                if (graficoLeituras) {
+                    graficoLeituras.data.labels = labels;
+                    graficoLeituras.data.datasets[0].data = valores;
+                    graficoLeituras.update();
+                } else {
+                    graficoLeituras = new Chart(ctx, {
+                        type: 'line',
+                        data: {
+                            labels: labels,
+                            datasets: [{
+                                label: 'Nível do Córrego (m)',
+                                data: valores,
+                                borderColor: '#1e3c72',
+                                backgroundColor: 'rgba(30, 60, 114, 0.1)',
+                                fill: true,
+                                tension: 0.4
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            scales: {
+                                y: {
+                                    beginAtZero: true
+                                }
+                            }
+                        }
+                    });
                 }
-            }
-        }
+            });
+    }
+
+    const selectCorrego = document.getElementById('corrego');
+    carregarGrafico(selectCorrego.value);
+    selectCorrego.addEventListener('change', () => {
+        carregarGrafico(selectCorrego.value);
     });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add `LeituraDTO` for returning chart data
- extend `LeituraSensorRepository` and service to fetch last 24 readings
- expose REST endpoint in `LeituraSensorController`
- update `gestao_leitura_sensores.html` and `dashboard.html` to load chart data via fetch

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68455c667280832b80b06e3da9e33d86