### PR TITLE
Fix producer to always set alert type

### DIFF
--- a/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/messaging/AlertaProducer.java
+++ b/mvc-admin/src/main/java/com/alerta_sp/mvc_admin/messaging/AlertaProducer.java
@@ -4,6 +4,7 @@ import com.alerta_sp.mvc_admin.dto.AlertaDTO;
 import com.alerta_sp.mvc_admin.dto.MensagemAlertaDTO;
 import com.alerta_sp.mvc_admin.repository.CorregoRepository;
 import com.alerta_sp.mvc_admin.model.Corrego;
+import com.alerta_sp.mvc_admin.model.TipoAlerta;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -36,6 +37,14 @@ public class AlertaProducer {
                 dto.getNivel(),
                 dto.getIdCorrego()
         );
+
+        // Garante que o campo 'tipo' esteja sempre definido
+        try {
+            String tipo = TipoAlerta.valueOf(dto.getNivel()).name();
+            mensagemDTO.setTipo(tipo);
+        } catch (Exception ex) {
+            mensagemDTO.setTipo("INDEFINIDO");
+        }
 
         rabbitTemplate.convertAndSend(exchange, routingKey, mensagemDTO);
         System.out.println("🚀 Alerta enviado via RabbitMQ: " + mensagemDTO);


### PR DESCRIPTION
## Summary
- ensure `AlertaProducer` always populates `tipo` for `MensagemAlertaDTO`

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684610643c8c832bbbae3a64d9c74223